### PR TITLE
Gal 749/remove all prev invitation link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ sbom-spdx*.json
 # testing
 /coverage
 
+# helpers
+/helpers
+
 # next.js
 /.next/
 /out/

--- a/src/app/styles/css/sass.css
+++ b/src/app/styles/css/sass.css
@@ -92,6 +92,11 @@ a:active {
 	}
 }
 
+/* custom pseudo-class for to hide the link until the reference page is complete */
+.unfinished-link {
+  display: none;
+}
+
 .nhsuk-link--no-visited-state:link {
 	color: #005eb8;
 }

--- a/src/app/styles/css/sass.css
+++ b/src/app/styles/css/sass.css
@@ -94,7 +94,7 @@ a:active {
 
 /* custom pseudo-class for to hide the link until the reference page is complete */
 .unfinished-link {
-  display: none;
+	display: none;
 }
 
 .nhsuk-link--no-visited-state:link {

--- a/src/app/views/clinic_information/RecentInvitationHistory.jsx
+++ b/src/app/views/clinic_information/RecentInvitationHistory.jsx
@@ -37,7 +37,7 @@ export default function RecentInvitationHistory(props) {
           <div style={{marginTop:"20px"}} className=".nhsuk-main-wrapper--l">
             <a
               id="changeCancelButtonId"
-              className="nhsuk-link--no-visited-state"
+              className="unfinished-link nhsuk-link--no-visited-state"
               href=""
               style={{ textDecorationLine: "underline" }}
               onClick={(event) => {event.preventDefault();}}


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Temporarily hidden the "View all previous invitations" link on the clinic invitation screen with the use of custom css psuedo-class that hides it for now until the referenced page is complete. Can be reverted by removing the pseudo class on the <a> element.


## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
