### PR TITLE
gal-792# removed the aria-live attribute

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ sbom-spdx*.json
 # testing
 /coverage
 
+# helpers
+/helpers
+
 # next.js
 /.next/
 /out/

--- a/src/app/views/clinic_summary/ClinicSummaryPage.jsx
+++ b/src/app/views/clinic_summary/ClinicSummaryPage.jsx
@@ -53,7 +53,6 @@ export default function ClinicSummaryPage(props) {
               </select>
             </div>
           </div>
-          <div aria-live="polite" id="dynamic-update-region">
           {icbSelected === ""
             ? null
             : isContextLoaded && (
@@ -68,7 +67,6 @@ export default function ClinicSummaryPage(props) {
                 onCurrentPageChange={onCurrentPageChange}
               />
             )}
-            </div>
         </div>
         </div>
       </main>

--- a/src/app/views/clinic_summary/ClinicSummaryTable.jsx
+++ b/src/app/views/clinic_summary/ClinicSummaryTable.jsx
@@ -23,7 +23,6 @@ export default function ClinicSummaryTable(props) {
 
   return (
     <section>
-      {/* <h2 className="nhsuk-heading no-margin-bottom">Clinic List</h2> */}
       <table
         className="nhsuk-table-responsive nhsuk-u-margin-bottom-6"
         aria-labelledby="clinicTableCaption"


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Small improvement by removing the "aria-live" attribute on the Table that was shifting the screen reader focus directly to the table and auto-reading the table contents after selecting the ICB. Removing the attribute allows the screen reader focus to stay on the drop down menu, allowing user to manually jump the focus to table, resulting in a better screen reader experience.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
